### PR TITLE
add Content-Type header so that provided curl example works with rpc 0.5.5+

### DIFF
--- a/codelab/index.md
+++ b/codelab/index.md
@@ -787,13 +787,13 @@ adds "Shams the Destroyer" to the list of pirates:
 On Mac and Linux:
 
 ```
-curl -d '{"name":"Shams", "appellation":"Destroyer"}' http://localhost:8088/piratesApi/v1/pirate
+curl -H "Content-Type: application/json" -d '{"name":"Shams", "appellation":"Destroyer"}' http://localhost:8088/piratesApi/v1/pirate
 ```
 
 On Windows:
 
 ```
-curl -d "{\"name\":\"Shams\",\"appellation\":\"Destroyer\"}" http://localhost:8088/piratesApi/v1/pirate
+curl -H "Content-Type: application/json" -d "{\"name\":\"Shams\",\"appellation\":\"Destroyer\"}" http://localhost:8088/piratesApi/v1/pirate
 ```
 
 The `firePirate` method was annotated like this:


### PR DESCRIPTION
I spent most of today figuring out why my message objects were consistently initialized with null. Starting with version 0.5.5, rpc cares about the Content-Type. curl can say the content-type, but will only do it if you ask it to. I hope this saves someone else a bunch of mysterious debugging!